### PR TITLE
Add driver list servlet and JSP

### DIFF
--- a/src/main/java/com/example/Config/DataSeeder.java
+++ b/src/main/java/com/example/Config/DataSeeder.java
@@ -39,12 +39,14 @@ private final VehicleServiceImpl vehicleService;
         vehicleService.addToDriver(d1, new Vehicle("Toyota", 1600, "Gasolina", 0, "MTR001","AAA111","2020"));
         vehicleService.addToDriver(d1, new Vehicle("Mazda", 2000, "Gasolina", 1, "MTR002","BBB222","2019"));
         vehicleService.addToDriver(d1, new Vehicle("Ferrari", 1400, "Gasolina", 2, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d2, new Vehicle("Lamborginnie", 1500, "Gasolina", 3, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d2, new Vehicle("Terrenator", 1800, "Gasolina", 4, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d2, new Vehicle("El chevere", 1500, "Gasolina", 5, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d3, new Vehicle("Chebroleds", 2400, "Gasolina", 6, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d3, new Vehicle("Micky", 2600, "Gasolina", 7, "MTR003","CCC333","2018"));
-        vehicleService.addToDriver(d3, new Vehicle("Coyote", 2800, "Gasolina", 8, "MTR003","CCC333","2018"));
+
+        vehicleService.addToDriver(d2, new Vehicle("Lamborghini", 1500, "Gasolina", 3, "MTR004","DDD444","2017"));
+        vehicleService.addToDriver(d2, new Vehicle("Terrenator", 1800, "Gasolina", 4, "MTR005","EEE555","2016"));
+        vehicleService.addToDriver(d2, new Vehicle("El chevere", 1500, "Gasolina", 5, "MTR006","FFF666","2015"));
+
+        vehicleService.addToDriver(d3, new Vehicle("Chebroleds", 2400, "Gasolina", 6, "MTR007","GGG777","2014"));
+        vehicleService.addToDriver(d3, new Vehicle("Micky", 2600, "Gasolina", 7, "MTR008","HHH888","2013"));
+        vehicleService.addToDriver(d3, new Vehicle("Coyote", 2800, "Gasolina", 8, "MTR009","III999","2012"));
 
     }
 

--- a/src/main/java/com/example/services/impl/VehicleServiceImpl.java
+++ b/src/main/java/com/example/services/impl/VehicleServiceImpl.java
@@ -31,7 +31,6 @@ public class VehicleServiceImpl implements IVehicleService{
     @Override
     public void addToDriver(Driver driver, Vehicle vehicle) {
         vehicleRepository.addToDriver(driver, vehicle);
-        driver.addToDriver(vehicle);
     }
 
     @Override

--- a/src/main/java/com/example/servlet/DriverListServlet.java
+++ b/src/main/java/com/example/servlet/DriverListServlet.java
@@ -1,0 +1,38 @@
+package com.example.servlet;
+
+import java.io.IOException;
+
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.context.support.WebApplicationContextUtils;
+
+import com.example.services.IDriverService;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(name="drivers", value="/drivers")
+public class DriverListServlet extends HttpServlet {
+    private IDriverService driverService;
+
+    @Override
+    public void init() throws ServletException {
+        WebApplicationContext ctx = WebApplicationContextUtils
+                .getRequiredWebApplicationContext(getServletContext());
+        this.driverService = ctx.getBean(IDriverService.class);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws IOException, ServletException {
+        response.setContentType("text/html");
+        request.setCharacterEncoding("UTF-8");
+        response.setCharacterEncoding("UTF-8");
+
+        request.setAttribute("drivers", driverService.findAll());
+        request.getRequestDispatcher("/WEB-INF/views/drivers.jsp")
+                .forward(request, response);
+    }
+}

--- a/src/main/webapp/WEB-INF/views/drivers.jsp
+++ b/src/main/webapp/WEB-INF/views/drivers.jsp
@@ -1,0 +1,41 @@
+<%@ page contentType="text/html; charset=UTF-8" %>
+<html>
+  <head><title>Drivers</title></head>
+  <body>
+    <h1>Driver List</h1>
+    <table border="1" cellpadding="6">
+      <tr>
+        <th>ID</th><th>Nombre</th><th>Cargo</th>
+        <th>Tipo ID</th><th>Número ID</th><th>Vehículos</th>
+      </tr>
+      <%
+        java.util.List<com.example.model.Driver> list =
+            (java.util.List<com.example.model.Driver>) request.getAttribute("drivers");
+        if (list != null) {
+          for (com.example.model.Driver d : list) {
+      %>
+      <tr>
+        <td><%= d.getId() %></td>
+        <td><%= d.getName() %></td>
+        <td><%= d.getPosition() %></td>
+        <td><%= d.getId_type() %></td>
+        <td><%= d.getId_number() %></td>
+        <td>
+          <ul>
+          <%
+            for (com.example.model.Vehicle v : d.getVehicles()) {
+          %>
+            <li><%= v.getPlate() %> - <%= v.getBrand() %></li>
+          <%
+            }
+          %>
+          </ul>
+        </td>
+      </tr>
+      <%
+          }
+        }
+      %>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Display drivers and their vehicles via new `/drivers` endpoint
- Add JSP view for listing drivers with associated vehicles
- Seed initial dataset with unique vehicle plates and motor numbers
- Remove redundant driver association in vehicle service

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68acc0d01fbc832eb861c34e74e87435