### PR TITLE
Configuracion XML de Spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
-[![Review Assignment Due Date](https://classroom.github.com/assets/deadline-readme-button-22041afd0340ce965d47ae6ef1cefeee28c7c493a6346c4f15d667ab976d596c.svg)](https://classroom.github.com/a/5bNPY7lO)
+# Parking Management
 
-Hola github
+Aplicación de ejemplo que utiliza **Spring Framework** configurado mediante
+`applicationContext.xml` para manejar los beans del dominio.
+
+## Compilación
+
+```bash
+mvn clean package
+```
+
+## Ejecución
+
+Para ejecutar la clase de demostración:
+
+```bash
+java -cp target/parking_management/WEB-INF/classes:\
+"$(find target/parking_management/WEB-INF/lib -name '*.jar' -printf '%p:')" \
+com.example.DebugApp
+```
+
+El comando anterior construye la ruta de clases necesaria para ejecutar la
+aplicación desde la línea de comandos. Alternativamente, el archivo WAR
+generado puede desplegarse en cualquier contenedor de servlets compatible con
+Jakarta EE.
+

--- a/src/main/java/com/example/Config/DataSeeder.java
+++ b/src/main/java/com/example/Config/DataSeeder.java
@@ -1,16 +1,9 @@
 package com.example.Config;
 
-import org.springframework.stereotype.Component;
-
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.services.impl.DriverServiceImpl;
 import com.example.services.impl.VehicleServiceImpl;
-
-import jakarta.annotation.PostConstruct;
-
-
-@Component
 public class DataSeeder {
 
 private final DriverServiceImpl  driverService;
@@ -21,7 +14,6 @@ private final VehicleServiceImpl vehicleService;
 
     }
 
-    @PostConstruct
     public void init(){
 
         // Instancias de conductor

--- a/src/main/java/com/example/DebugApp.java
+++ b/src/main/java/com/example/DebugApp.java
@@ -1,8 +1,6 @@
 package com.example;
 
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-
-import com.example.Config.AppConfig;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.services.IDriverService;
@@ -11,7 +9,7 @@ import com.example.services.IVehicleService;
 public class DebugApp {
 
     public static void main(String[] args) {
-        try (var ctx = new AnnotationConfigApplicationContext(AppConfig.class)) {
+        try (var ctx = new ClassPathXmlApplicationContext("applicationContext.xml")) {
 
             // 1) Obtener beans (services)
             IDriverService driverService = ctx.getBean(IDriverService.class);

--- a/src/main/java/com/example/repository/impl/DriverRepositoryImpl.java
+++ b/src/main/java/com/example/repository/impl/DriverRepositoryImpl.java
@@ -3,12 +3,8 @@ package com.example.repository.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
 import com.example.model.Driver;
 import com.example.repository.IDriverRepository;
-
-@Repository()
 public class DriverRepositoryImpl implements IDriverRepository{
 
     List<Driver> drivers = new ArrayList<>();

--- a/src/main/java/com/example/repository/impl/VehicleRepositoryImpl.java
+++ b/src/main/java/com/example/repository/impl/VehicleRepositoryImpl.java
@@ -3,13 +3,10 @@ package com.example.repository.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.repository.IVehicleRepository;
 
-@Repository
 public class VehicleRepositoryImpl implements IVehicleRepository{
 
     private final List<Vehicle> vehicles = new  ArrayList<>();

--- a/src/main/java/com/example/services/impl/DriverServiceImpl.java
+++ b/src/main/java/com/example/services/impl/DriverServiceImpl.java
@@ -2,14 +2,11 @@ package com.example.services.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Service;
-
 import com.example.model.Driver;
 import com.example.repository.impl.DriverRepositoryImpl;
 import com.example.repository.impl.VehicleRepositoryImpl;
 import com.example.services.IDriverService;
 
-@Service 
 public class DriverServiceImpl implements IDriverService{
 
     private final DriverRepositoryImpl driverRepository;

--- a/src/main/java/com/example/services/impl/VehicleServiceImpl.java
+++ b/src/main/java/com/example/services/impl/VehicleServiceImpl.java
@@ -2,14 +2,11 @@ package com.example.services.impl;
 
 import java.util.List;
 
-import org.springframework.stereotype.Service;
-
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.repository.impl.VehicleRepositoryImpl;
 import com.example.services.IVehicleService;
 
-@Service
 public class VehicleServiceImpl implements IVehicleService{
 
     private VehicleRepositoryImpl vehicleRepository;

--- a/src/main/java/com/example/servlet/AplicationServlet.java
+++ b/src/main/java/com/example/servlet/AplicationServlet.java
@@ -3,8 +3,7 @@ package com.example.servlet;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
@@ -21,12 +20,12 @@ public class AplicationServlet extends HttpServlet{
 
     private String message;
     private IVehicleService vehicleService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init(){
          message = "Búsqueda por placa";
-         WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+         ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
          this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 
@@ -78,6 +77,9 @@ public class AplicationServlet extends HttpServlet{
 
     @Override
     public void destroy(){
+        if (ctx != null) {
+            ctx.close();
+        }
         message = "This servlet is not running";
     }
 

--- a/src/main/java/com/example/servlet/DriverAddServlet.java
+++ b/src/main/java/com/example/servlet/DriverAddServlet.java
@@ -2,8 +2,7 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.model.Driver;
 import com.example.services.IDriverService;
@@ -17,11 +16,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="addDriver", value="/driver/add")
 public class DriverAddServlet extends HttpServlet {
     private IDriverService driverService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.driverService = ctx.getBean(IDriverService.class);
     }
 
@@ -52,5 +51,12 @@ public class DriverAddServlet extends HttpServlet {
 
         request.setAttribute("message", message);
         request.getRequestDispatcher("/WEB-INF/views/addDriver.jsp").forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }

--- a/src/main/java/com/example/servlet/DriverListServlet.java
+++ b/src/main/java/com/example/servlet/DriverListServlet.java
@@ -2,8 +2,7 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.services.IDriverService;
 
@@ -16,11 +15,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="drivers", value="/drivers")
 public class DriverListServlet extends HttpServlet {
     private IDriverService driverService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.driverService = ctx.getBean(IDriverService.class);
     }
 
@@ -34,5 +33,12 @@ public class DriverListServlet extends HttpServlet {
         request.setAttribute("drivers", driverService.findAll());
         request.getRequestDispatcher("/WEB-INF/views/drivers.jsp")
                 .forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }

--- a/src/main/java/com/example/servlet/DriverVehiclesServlet.java
+++ b/src/main/java/com/example/servlet/DriverVehiclesServlet.java
@@ -3,8 +3,7 @@ package com.example.servlet;
 import java.io.IOException;
 import java.util.List;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.model.Driver;
 import com.example.model.Vehicle;
@@ -19,11 +18,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="driverVehicles", value="/driver/vehicles")
 public class DriverVehiclesServlet extends HttpServlet {
     private IDriverService driverService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.driverService = ctx.getBean(IDriverService.class);
     }
 
@@ -59,5 +58,12 @@ public class DriverVehiclesServlet extends HttpServlet {
         request.setAttribute("message", message);
         request.getRequestDispatcher("/WEB-INF/views/driverVehicles.jsp")
                .forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }

--- a/src/main/java/com/example/servlet/VehicleAddServlet.java
+++ b/src/main/java/com/example/servlet/VehicleAddServlet.java
@@ -2,8 +2,7 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
@@ -17,11 +16,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="addVehicle", value="/vehicle/add")
 public class VehicleAddServlet extends HttpServlet {
     private IVehicleService vehicleService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 
@@ -59,5 +58,12 @@ public class VehicleAddServlet extends HttpServlet {
 
         request.setAttribute("message", message);
         request.getRequestDispatcher("/WEB-INF/views/addVehicle.jsp").forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }

--- a/src/main/java/com/example/servlet/VehicleDeleteServlet.java
+++ b/src/main/java/com/example/servlet/VehicleDeleteServlet.java
@@ -2,8 +2,7 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
@@ -17,11 +16,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="deleteVehicle", value="/vehicle/delete")
 public class VehicleDeleteServlet extends HttpServlet {
     private IVehicleService vehicleService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 
@@ -51,6 +50,13 @@ public class VehicleDeleteServlet extends HttpServlet {
         request.setAttribute("message", message);
         request.getRequestDispatcher("/WEB-INF/views/deleteVehicle.jsp")
                .forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }
 

--- a/src/main/java/com/example/servlet/VehicleListServlet.java
+++ b/src/main/java/com/example/servlet/VehicleListServlet.java
@@ -2,8 +2,7 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.web.context.WebApplicationContext;
-import org.springframework.web.context.support.WebApplicationContextUtils;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import com.example.services.IVehicleService;
 
@@ -16,11 +15,11 @@ import jakarta.servlet.http.HttpServletResponse;
  @WebServlet(name="vehiculos", value="/vehicle")
 public class VehicleListServlet extends HttpServlet {
     private IVehicleService vehicleService;
+    private ClassPathXmlApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        WebApplicationContext ctx = WebApplicationContextUtils
-                .getRequiredWebApplicationContext(getServletContext());
+        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 
@@ -35,6 +34,13 @@ public class VehicleListServlet extends HttpServlet {
 
         request.setAttribute("vehicles", vehicleService.findAll());
         request.getRequestDispatcher("/WEB-INF/views/vehicles.jsp")
-               .forward(request, response); 
+               .forward(request, response);
+    }
+
+    @Override
+    public void destroy() {
+        if (ctx != null) {
+            ctx.close();
+        }
     }
 }

--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                           https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="driverRepository" class="com.example.repository.impl.DriverRepositoryImpl"/>
+    <bean id="vehicleRepository" class="com.example.repository.impl.VehicleRepositoryImpl"/>
+
+    <bean id="driverService" class="com.example.services.impl.DriverServiceImpl">
+        <constructor-arg ref="driverRepository"/>
+        <constructor-arg ref="vehicleRepository"/>
+    </bean>
+
+    <bean id="vehicleService" class="com.example.services.impl.VehicleServiceImpl">
+        <constructor-arg ref="vehicleRepository"/>
+    </bean>
+
+    <bean id="dataSeeder" class="com.example.Config.DataSeeder" init-method="init">
+        <constructor-arg ref="driverService"/>
+        <constructor-arg ref="vehicleService"/>
+    </bean>
+
+</beans>
+


### PR DESCRIPTION
## Summary
- Define Spring beans in `applicationContext.xml` and drop stereotype annotations from repositories, services and seeder.
- Use `ClassPathXmlApplicationContext` in `DebugApp` and all servlets for bean lookup.
- Document compilation and execution steps in `README`.

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68acd868c860832eba9cf3afbece8716