### PR TITLE
Configurar beans explícitos sin estereotipos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Parking Management
 
 Aplicación de ejemplo que utiliza **Spring Framework**. Puede configurarse
-mediante el tradicional archivo `applicationContext.xml` o usando clases
-anotadas con `@Configuration` y `@ComponentScan`.
+mediante el tradicional archivo `applicationContext.xml`, usando clases
+anotadas con `@Configuration` y `@ComponentScan`, o declarando los beans
+explícitamente en una clase de configuración.
 
 ## Compilación
 
@@ -15,7 +16,21 @@ mvn clean package
 ### Versión anotada
 
 `DebugApp` carga el contexto con `AnnotationConfigApplicationContext` y la
-clase `AppConfig`.
+clase `AppConfig`, que utiliza `@ComponentScan` para detectar los beans
+anotados con estereotipos como `@Service` o `@Repository`.
+
+```bash
+java -cp target/parking_management/WEB-INF/classes:\
+"$(find target/parking_management/WEB-INF/lib -name '*.jar' -printf '%p:')" \
+com.example.DebugApp
+```
+
+### Versión Java con `@Bean`
+
+En esta variante, `AppConfig` declara cada bean de forma manual mediante
+métodos `@Bean`. Las clases de servicios y repositorios no llevan anotaciones
+de estereotipo y las dependencias se registran directamente en la clase de
+configuración.
 
 ```bash
 java -cp target/parking_management/WEB-INF/classes:\
@@ -34,7 +49,7 @@ java -cp target/parking_management/WEB-INF/classes:\
 com.example.DebugAppXml
 ```
 
-Ambos comandos construyen la ruta de clases necesaria para ejecutar la
+Los comandos anteriores construyen la ruta de clases necesaria para ejecutar la
 aplicación desde la línea de comandos. Alternativamente, el archivo WAR
 generado puede desplegarse en cualquier contenedor de servlets compatible con
 Jakarta EE.

--- a/src/main/java/com/example/Config/AppConfig.java
+++ b/src/main/java/com/example/Config/AppConfig.java
@@ -1,11 +1,44 @@
 package com.example.Config;
 
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.example.repository.IDriverRepository;
+import com.example.repository.IVehicleRepository;
+import com.example.repository.impl.DriverRepositoryImpl;
+import com.example.repository.impl.VehicleRepositoryImpl;
+import com.example.services.IDriverService;
+import com.example.services.IVehicleService;
+import com.example.services.impl.DriverServiceImpl;
+import com.example.services.impl.VehicleServiceImpl;
+
 @Configuration
-@ComponentScan(basePackages="com.example")
 public class AppConfig {
-    
+
+    @Bean
+    public IDriverRepository driverRepository() {
+        return new DriverRepositoryImpl();
+    }
+
+    @Bean
+    public IVehicleRepository vehicleRepository() {
+        return new VehicleRepositoryImpl();
+    }
+
+    @Bean
+    public IDriverService driverService(IDriverRepository driverRepository,
+            IVehicleRepository vehicleRepository) {
+        return new DriverServiceImpl(driverRepository, vehicleRepository);
+    }
+
+    @Bean
+    public IVehicleService vehicleService(IVehicleRepository vehicleRepository) {
+        return new VehicleServiceImpl(vehicleRepository);
+    }
+
+    @Bean
+    public DataSeeder dataSeeder(IDriverService driverService, IVehicleService vehicleService) {
+        return new DataSeeder(driverService, vehicleService);
+    }
 }
 

--- a/src/main/java/com/example/Config/DataSeeder.java
+++ b/src/main/java/com/example/Config/DataSeeder.java
@@ -1,8 +1,5 @@
 package com.example.Config;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
-
 import jakarta.annotation.PostConstruct;
 
 import com.example.model.Driver;
@@ -10,13 +7,11 @@ import com.example.model.Vehicle;
 import com.example.services.IDriverService;
 import com.example.services.IVehicleService;
 
-@Component
 public class DataSeeder {
 
     private final IDriverService driverService;
     private final IVehicleService vehicleService;
 
-    @Autowired
     public DataSeeder(IDriverService driverService, IVehicleService vehicleService) {
         this.driverService = driverService;
         this.vehicleService = vehicleService;

--- a/src/main/java/com/example/DebugApp.java
+++ b/src/main/java/com/example/DebugApp.java
@@ -11,6 +11,7 @@ import com.example.services.IVehicleService;
 public class DebugApp {
 
     public static void main(String[] args) {
+        // Context based on explicit @Bean definitions in AppConfig
         try (var ctx = new AnnotationConfigApplicationContext(AppConfig.class)) {
 
             // 1) Obtener beans (services)

--- a/src/main/java/com/example/repository/impl/DriverRepositoryImpl.java
+++ b/src/main/java/com/example/repository/impl/DriverRepositoryImpl.java
@@ -3,12 +3,9 @@ package com.example.repository.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
 import com.example.model.Driver;
 import com.example.repository.IDriverRepository;
 
-@Repository
 public class DriverRepositoryImpl implements IDriverRepository {
 
     private final List<Driver> drivers = new ArrayList<>();

--- a/src/main/java/com/example/repository/impl/VehicleRepositoryImpl.java
+++ b/src/main/java/com/example/repository/impl/VehicleRepositoryImpl.java
@@ -3,13 +3,10 @@ package com.example.repository.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.springframework.stereotype.Repository;
-
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.repository.IVehicleRepository;
 
-@Repository
 public class VehicleRepositoryImpl implements IVehicleRepository {
 
     private final List<Vehicle> vehicles = new ArrayList<>();

--- a/src/main/java/com/example/services/impl/DriverServiceImpl.java
+++ b/src/main/java/com/example/services/impl/DriverServiceImpl.java
@@ -2,21 +2,16 @@ package com.example.services.impl;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import com.example.model.Driver;
 import com.example.repository.IDriverRepository;
 import com.example.repository.IVehicleRepository;
 import com.example.services.IDriverService;
 
-@Service
 public class DriverServiceImpl implements IDriverService {
 
     private final IDriverRepository driverRepository;
     private final IVehicleRepository vehicleRepository;
 
-    @Autowired
     public DriverServiceImpl(IDriverRepository driverRepository, IVehicleRepository vehicleRepository) {
         this.driverRepository = driverRepository;
         this.vehicleRepository = vehicleRepository;

--- a/src/main/java/com/example/services/impl/VehicleServiceImpl.java
+++ b/src/main/java/com/example/services/impl/VehicleServiceImpl.java
@@ -2,20 +2,15 @@ package com.example.services.impl;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.repository.IVehicleRepository;
 import com.example.services.IVehicleService;
 
-@Service
 public class VehicleServiceImpl implements IVehicleService {
 
     private final IVehicleRepository vehicleRepository;
 
-    @Autowired
     public VehicleServiceImpl(IVehicleRepository vRepository) {
         this.vehicleRepository = vRepository;
     }

--- a/src/main/java/com/example/servlet/AplicationServlet.java
+++ b/src/main/java/com/example/servlet/AplicationServlet.java
@@ -3,8 +3,9 @@ package com.example.servlet;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
 
@@ -20,12 +21,12 @@ public class AplicationServlet extends HttpServlet{
 
     private String message;
     private IVehicleService vehicleService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init(){
          message = "Búsqueda por placa";
-         ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+         ctx = new AnnotationConfigApplicationContext(AppConfig.class);
          this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 

--- a/src/main/java/com/example/servlet/DriverAddServlet.java
+++ b/src/main/java/com/example/servlet/DriverAddServlet.java
@@ -2,8 +2,9 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.model.Driver;
 import com.example.services.IDriverService;
 
@@ -16,11 +17,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="addDriver", value="/driver/add")
 public class DriverAddServlet extends HttpServlet {
     private IDriverService driverService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.driverService = ctx.getBean(IDriverService.class);
     }
 

--- a/src/main/java/com/example/servlet/DriverListServlet.java
+++ b/src/main/java/com/example/servlet/DriverListServlet.java
@@ -2,8 +2,9 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.services.IDriverService;
 
 import jakarta.servlet.ServletException;
@@ -15,11 +16,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="drivers", value="/drivers")
 public class DriverListServlet extends HttpServlet {
     private IDriverService driverService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.driverService = ctx.getBean(IDriverService.class);
     }
 

--- a/src/main/java/com/example/servlet/DriverVehiclesServlet.java
+++ b/src/main/java/com/example/servlet/DriverVehiclesServlet.java
@@ -3,8 +3,9 @@ package com.example.servlet;
 import java.io.IOException;
 import java.util.List;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.model.Driver;
 import com.example.model.Vehicle;
 import com.example.services.IDriverService;
@@ -18,11 +19,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="driverVehicles", value="/driver/vehicles")
 public class DriverVehiclesServlet extends HttpServlet {
     private IDriverService driverService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.driverService = ctx.getBean(IDriverService.class);
     }
 

--- a/src/main/java/com/example/servlet/VehicleAddServlet.java
+++ b/src/main/java/com/example/servlet/VehicleAddServlet.java
@@ -2,8 +2,9 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
 
@@ -16,11 +17,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="addVehicle", value="/vehicle/add")
 public class VehicleAddServlet extends HttpServlet {
     private IVehicleService vehicleService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 

--- a/src/main/java/com/example/servlet/VehicleDeleteServlet.java
+++ b/src/main/java/com/example/servlet/VehicleDeleteServlet.java
@@ -2,8 +2,9 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.model.Vehicle;
 import com.example.services.IVehicleService;
 
@@ -16,11 +17,11 @@ import jakarta.servlet.http.HttpServletResponse;
 @WebServlet(name="deleteVehicle", value="/vehicle/delete")
 public class VehicleDeleteServlet extends HttpServlet {
     private IVehicleService vehicleService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 

--- a/src/main/java/com/example/servlet/VehicleListServlet.java
+++ b/src/main/java/com/example/servlet/VehicleListServlet.java
@@ -2,8 +2,9 @@ package com.example.servlet;
 
 import java.io.IOException;
 
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
+import com.example.Config.AppConfig;
 import com.example.services.IVehicleService;
 
 import jakarta.servlet.ServletException;
@@ -15,11 +16,11 @@ import jakarta.servlet.http.HttpServletResponse;
  @WebServlet(name="vehiculos", value="/vehicle")
 public class VehicleListServlet extends HttpServlet {
     private IVehicleService vehicleService;
-    private ClassPathXmlApplicationContext ctx;
+    private AnnotationConfigApplicationContext ctx;
 
     @Override
     public void init() throws ServletException {
-        ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+        ctx = new AnnotationConfigApplicationContext(AppConfig.class);
         this.vehicleService = ctx.getBean(IVehicleService.class);
     }
 


### PR DESCRIPTION
## Summary
- Registrar repositorios, servicios y el `DataSeeder` mediante métodos `@Bean` en `AppConfig`
- Eliminar anotaciones de estereotipo y dejar la inyección en manos de la configuración Java
- Servlets y `DebugApp` crean el contexto con `AnnotationConfigApplicationContext(AppConfig.class)`
- Documentar en el README cómo ejecutar la variante con beans explícitos

## Testing
- `mvn -q test` *(falla: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acdbee4008832ea57de066816390f0